### PR TITLE
Use `STATIC_URL` from env

### DIFF
--- a/qpass/build.sh
+++ b/qpass/build.sh
@@ -9,7 +9,7 @@ CGO_ENABLED=0 go build
 # Build frontend
 cd web
 yarn install --frozen-lockfile --network-timeout 1000000
-FRONTEND_ENV=production yarn run build
+STATIC_URL=${STATIC_URL:-https://acc-static.gopluscdn.com/} yarn run build
 cd ..
 
 # Copy result

--- a/web/craco.config.js
+++ b/web/craco.config.js
@@ -1,7 +1,7 @@
 const CracoLessPlugin = require("craco-less");
 
 // We use CDN for static files in production
-const staticUrl = process.env.FRONTEND_ENV === 'production' ? 'https://acc-static.gopluscdn.com/' : '/'
+const staticUrl = process.env.STATIC_URL || '/'
 
 module.exports = {
   devServer: {


### PR DESCRIPTION
Run

```sh
STATIC_URL=https://example.com/ sh ./qpass/build.sh
```

to specify other base URL for static assets.